### PR TITLE
Two bug fixes

### DIFF
--- a/lib/util.ts
+++ b/lib/util.ts
@@ -88,3 +88,8 @@ export function validatePaginationArgs(args: RawPaginationArgs) {
 export function map<T, R>(t: T | null | undefined, fn: (t: T) => R) {
   return nullish(t) ? t : fn(t);
 }
+
+export function inspect<T>(t: T) {
+  console.debug("t =:", t);
+  return t;
+}

--- a/schema.graphql
+++ b/schema.graphql
@@ -90,7 +90,8 @@ input AssigneeInput {
 }
 
 type AssignmentPayload {
-  assignedTo: Assignable!
+  assignedTo: Assignable! @deprecated
+  assignee: AssigneeEdge!
   entity: Assignable!
 }
 
@@ -1179,7 +1180,8 @@ scalar URL
 
 type UnassignmentPayload {
   entity: Assignable!
-  unassignedFrom: Assignable!
+  unassignedAssignees: [ID!]!
+  unassignedFrom: Assignable! @deprecated
 }
 
 input UpdateLocationInput {

--- a/schema/application/resolvers/Mutation/copyFrom.ts
+++ b/schema/application/resolvers/Mutation/copyFrom.ts
@@ -8,6 +8,7 @@ import type {
 import { decodeGlobalId } from "@/schema/system";
 import { map } from "@/util";
 import { GraphQLError } from "graphql";
+import type { TransactionSql } from "postgres";
 import { match } from "ts-pattern";
 
 export const copyFrom: NonNullable<MutationResolvers["copyFrom"]> = async (
@@ -18,7 +19,9 @@ export const copyFrom: NonNullable<MutationResolvers["copyFrom"]> = async (
 
   switch (type) {
     case "worktemplate":
-      return copyFromWorkTemplate(id, options);
+      return sql.begin(tx => copyFromWorkTemplate(tx, id, options));
+    case "workinstance":
+      return sql.begin(tx => copyFromWorkInstance(tx, id, options));
     default: {
       console.debug(
         `The type of the lhs of the copy operation is invalid. Got: '${type}'. Expected one of: ['worktemplate']`,
@@ -32,154 +35,170 @@ export const copyFrom: NonNullable<MutationResolvers["copyFrom"]> = async (
   }
 };
 
-export async function copyFromWorkTemplate(
+// TODO: We could extend the `options` here to include things like:
+// - copying over result statuses, values
+// - ...?
+export async function copyFromWorkInstance(
+  tx: TransactionSql,
   id: string,
   options: CopyFromOptions,
 ): Promise<CopyFromPayload> {
-  const [edge] = await sql.begin(async tx => {
-    const [row] = await tx<[{ _key: number; id: string }?]>`
-        INSERT INTO public.workinstance (
-            workinstancecustomerid,
-            workinstancesiteid,
-            workinstancesoplink,
-            workinstancestartdate,
-            workinstancestatusid,
-            workinstancetypeid,
-            workinstanceworktemplateid,
-            workinstancetimezone
-        )
-        SELECT
-            worktemplatecustomerid,
-            worktemplatesiteid,
-            worktemplatesoplink,
-            ${match(options.withStatus)
-              .with("open", () => null)
-              .with("inProgress", () => sql`now()`)
-              .with("closed", () => sql`now()`)
-              .with(undefined, () => null)
-              .exhaustive()},
-            (
-                SELECT systagid
-                FROM public.systag
-                WHERE
-                    systagparentid = 705
-                    AND systagtype = ${match(options.withStatus)
-                      .with("open", () => "Open")
-                      .with("inProgress", () => "In Progress")
-                      .with("closed", () => "Complete")
-                      .with(undefined, () => "Open")
-                      .exhaustive()}
-            ) AS workinstancestatusid,
-            (
-                SELECT systagid
-                FROM public.systag
-                WHERE
-                    systagparentid = 691
-                    AND systagtype = 'On Demand'
-            ) AS workinstancetypeid,
-            worktemplateid,
-            locationtimezone
-        FROM public.worktemplate
-        INNER JOIN public.location ON
-            worktemplatesiteid = locationid
-        WHERE worktemplate.id = ${id}
-        RETURNING
-            workinstanceid AS "_key",
-            encode(('workinstance:' || workinstance.id)::bytea, 'base64') AS id
-    `;
+  const [row] = await tx<[{ id: string }]>`
+      SELECT wt.id
+      FROM public.workinstance AS wi
+      INNER JOIN public.worktemplate AS wt
+          ON wi.workinstanceworktemplateid = wt.worktemplateid
+      WHERE wi.id = ${id};
+  `;
+  // For now, we just do a template-based copy:
+  return copyFromWorkTemplate(tx, row.id, options);
+}
 
-    if (!row) {
-      console.debug(`No worktemplate exists for the given id '${id}'`);
-      throw "invariant violated";
-    }
+export async function copyFromWorkTemplate(
+  tx: TransactionSql,
+  id: string,
+  options: CopyFromOptions,
+): Promise<CopyFromPayload> {
+  const [row] = await tx<[{ _key: number; id: string }?]>`
+      INSERT INTO public.workinstance (
+          workinstancecustomerid,
+          workinstancesiteid,
+          workinstancesoplink,
+          workinstancestartdate,
+          workinstancestatusid,
+          workinstancetypeid,
+          workinstanceworktemplateid,
+          workinstancetimezone
+      )
+      SELECT
+          worktemplatecustomerid,
+          worktemplatesiteid,
+          worktemplatesoplink,
+          ${match(options.withStatus)
+            .with("open", () => null)
+            .with("inProgress", () => sql`now()`)
+            .with("closed", () => sql`now()`)
+            .with(undefined, () => null)
+            .exhaustive()},
+          (
+              SELECT systagid
+              FROM public.systag
+              WHERE
+                  systagparentid = 705
+                  AND systagtype = ${match(options.withStatus)
+                    .with("open", () => "Open")
+                    .with("inProgress", () => "In Progress")
+                    .with("closed", () => "Complete")
+                    .with(undefined, () => "Open")
+                    .exhaustive()}
+          ) AS workinstancestatusid,
+          (
+              SELECT systagid
+              FROM public.systag
+              WHERE
+                  systagparentid = 691
+                  AND systagtype = 'On Demand'
+          ) AS workinstancetypeid,
+          worktemplateid,
+          locationtimezone
+      FROM public.worktemplate
+      INNER JOIN public.location ON
+          worktemplatesiteid = locationid
+      WHERE worktemplate.id = ${id}
+      RETURNING
+          workinstanceid AS "_key",
+          encode(('workinstance:' || workinstance.id)::bytea, 'base64') AS id
+  `;
 
-    const result = await tx`
-        INSERT INTO public.workresultinstance (
-            workresultinstancecompleteddate,
-            workresultinstancecustomerid,
-            workresultinstancestartdate,
-            workresultinstancevalue,
-            workresultinstanceworkinstanceid,
-            workresultinstanceworkresultid,
-            workresultinstancestatusid,
-            workresultinstancetimezone
-        )
-        SELECT
-            workinstancecompleteddate,
-            worktemplatecustomerid,
-            workinstancestartdate,
-            (
-                SELECT location.locationid::text AS value
-                WHERE entity_type.systagtype = 'Location' AND workresultisprimary
-                UNION ALL
-                SELECT ${
-                  map(options.withAssignee?.at(0), a => {
-                    const { type, id } = decodeGlobalId(a);
-                    if (type !== "worker") {
-                      console.debug(
-                        `Only 'worker's can be assignees at the moment, but got '${type}'`,
-                      );
-                      throw new GraphQLError("Entity cannot be assigned", {
-                        extensions: {
-                          code: "E_NOT_ASSIGNABLE",
-                        },
-                      });
-                    }
-                    return sql`workerinstanceid
-                        FROM public.workerinstance
-                        WHERE workerinstanceuuid = ${id}`;
-                  }) ?? null
-                }::text AS value
-                WHERE entity_type.systagtype = 'Worker' AND workresultisprimary
-                UNION ALL
-                SELECT null::text AS value
-                WHERE
-                    entity_type IS null
-                    OR (
-                        entity_type IS NOT null
-                        AND workresultisprimary = false
-                    )
-            ) AS workresultinstancevalue,
-            ${row._key}::bigint AS workresultinstanceworkinstanceid,
-            workresultid,
-            (
-                SELECT systagid
-                FROM public.systag
-                WHERE
-                    systagparentid = 965
-                    AND systagtype = ${match(options.withStatus)
-                      .with("open", () => "Open")
-                      .with("inProgress", () => "Open")
-                      .with("closed", () => "Complete")
-                      .with(undefined, () => "Open")
-                      .exhaustive()}
-            ) AS workresultinstancestatusid,
-            locationtimezone
-        FROM public.workresult
-        INNER JOIN public.worktemplate
-            ON workresultworktemplateid = worktemplateid
-        INNER JOIN public.location
-            ON worktemplatesiteid = locationid
-        INNER JOIN public.workinstance
-            ON workinstance.workinstanceid = ${row._key}
-        LEFT JOIN public.systag AS entity_type
-            ON workresultentitytypeid = systagid
-        WHERE
-            worktemplate.id = ${id}
-    `;
+  if (!row) {
+    console.debug(`No worktemplate exists for the given id '${id}'`);
+    throw "invariant violated";
+  }
 
-    console.debug(`Created ${result.count} items.`);
+  const result = await tx`
+      INSERT INTO public.workresultinstance (
+          workresultinstancecompleteddate,
+          workresultinstancecustomerid,
+          workresultinstancestartdate,
+          workresultinstancevalue,
+          workresultinstanceworkinstanceid,
+          workresultinstanceworkresultid,
+          workresultinstancestatusid,
+          workresultinstancetimezone
+      )
+      SELECT
+          workinstancecompleteddate,
+          worktemplatecustomerid,
+          workinstancestartdate,
+          (
+              SELECT location.locationid::text AS value
+              WHERE entity_type.systagtype = 'Location' AND workresultisprimary
+              UNION ALL
+              SELECT ${
+                map(options.withAssignee?.at(0), a => {
+                  const { type, id } = decodeGlobalId(a);
+                  if (type !== "worker") {
+                    console.debug(
+                      `Only 'worker's can be assignees at the moment, but got '${type}'`,
+                    );
+                    throw new GraphQLError("Entity cannot be assigned", {
+                      extensions: {
+                        code: "E_NOT_ASSIGNABLE",
+                      },
+                    });
+                  }
+                  return sql`workerinstanceid
+                      FROM public.workerinstance
+                      WHERE workerinstanceuuid = ${id}`;
+                }) ?? null
+              }::text AS value
+              WHERE entity_type.systagtype = 'Worker' AND workresultisprimary
+              UNION ALL
+              SELECT null::text AS value
+              WHERE
+                  entity_type IS null
+                  OR (
+                      entity_type IS NOT null
+                      AND workresultisprimary = false
+                  )
+          ) AS workresultinstancevalue,
+          ${row._key}::bigint AS workresultinstanceworkinstanceid,
+          workresultid,
+          (
+              SELECT systagid
+              FROM public.systag
+              WHERE
+                  systagparentid = 965
+                  AND systagtype = ${match(options.withStatus)
+                    .with("open", () => "Open")
+                    .with("inProgress", () => "Open")
+                    .with("closed", () => "Complete")
+                    .with(undefined, () => "Open")
+                    .exhaustive()}
+          ) AS workresultinstancestatusid,
+          locationtimezone
+      FROM public.workresult
+      INNER JOIN public.worktemplate
+          ON workresultworktemplateid = worktemplateid
+      INNER JOIN public.location
+          ON worktemplatesiteid = locationid
+      INNER JOIN public.workinstance
+          ON workinstance.workinstanceid = ${row._key}
+      LEFT JOIN public.systag AS entity_type
+          ON workresultentitytypeid = systagid
+      WHERE
+          worktemplate.id = ${id}
+  `;
 
-    return [
-      {
-        cursor: row.id,
-        node: {
-          __typename: "Checklist",
-          id: row.id,
-        },
-      } as ChecklistEdge,
-    ];
-  });
+  console.debug(`Created ${result.count} items.`);
 
-  return { edge };
+  return {
+    edge: {
+      cursor: row.id,
+      node: {
+        __typename: "Checklist",
+        id: row.id,
+      },
+    } as ChecklistEdge,
+  };
 }

--- a/schema/application/resolvers/Mutation/discardChecklist.ts
+++ b/schema/application/resolvers/Mutation/discardChecklist.ts
@@ -50,7 +50,7 @@ export const discardChecklist: NonNullable<
         RETURNING wt.id
     `;
 
-    return copyFromWorkTemplate(data[0].id, {});
+    return copyFromWorkTemplate(tx, data[0].id, {});
   });
 
   return { edge: result.edge, discardedChecklistIds: [entity] };

--- a/schema/application/resolvers/Mutation/saveChecklist.ts
+++ b/schema/application/resolvers/Mutation/saveChecklist.ts
@@ -220,6 +220,10 @@ export const saveChecklist: NonNullable<
     console.log(
       `Applied ${delta} update(s) to Entity ${input.id} (${type}:${id})`,
     );
+
+    if (input.items?.length) {
+      await saveChecklistResults(id, input.items);
+    }
   } else {
     // else: create
     const result = await sql.begin(async tx => {
@@ -637,14 +641,14 @@ export const saveChecklist: NonNullable<
 
     const delta = result.reduce((acc, res) => acc + res.count, 0);
     console.log(`Created Entity ${input.id} by way of ${delta} operation(s)`);
-  }
 
-  if (input.items?.length) {
-    await saveChecklistResults(id, input.items);
-  }
+    if (input.items?.length) {
+      await saveChecklistResults(id, input.items);
+    }
 
-  // Create an Open instance of the newly created Checklist template.
-  await copyFromWorkTemplate(id, {});
+    // Create an Open instance of the newly created Checklist template.
+    await sql.begin(sql => copyFromWorkTemplate(sql, id, {}));
+  }
 
   return {
     cursor: input.id.toString(),

--- a/schema/application/resolvers/Query/checklists.ts
+++ b/schema/application/resolvers/Query/checklists.ts
@@ -17,7 +17,6 @@ import type { Fragment } from "postgres";
 import { match } from "ts-pattern";
 
 type ParentType = "organization" | "workinstance";
-type Row = { __typename: "Checklist"; id: string };
 
 export const checklists: NonNullable<QueryResolvers["checklists"]> = async (
   _,

--- a/schema/platform/components.schema.graphql
+++ b/schema/platform/components.schema.graphql
@@ -63,12 +63,14 @@ type AssignableEdge implements Edge {
 
 type AssignmentPayload {
   entity: Assignable!
-  assignedTo: Assignable!
+  assignedTo: Assignable! @deprecated
+  assignee: AssigneeEdge!
 }
 
 type UnassignmentPayload {
   entity: Assignable!
-  unassignedFrom: Assignable!
+  unassignedFrom: Assignable! @deprecated
+  unassignedAssignees: [ID!]!
 }
 
 extend type Query {


### PR DESCRIPTION
1. Run the rules engine (a very lame and stupid version) on status -> In Progress (this is the canonical On Demand rule)
2. Assigning, unassigning a Checklist now correctly causes the relevant (client) components to rerender